### PR TITLE
修复MT7621断LAN现象

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
@@ -179,6 +179,23 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
 	mt7530_mdio_w32(gsw, 0x7a6c, 0x44);
 	mt7530_mdio_w32(gsw, 0x7a74, 0x44);
 	mt7530_mdio_w32(gsw, 0x7a7c, 0x44);
+	
+	/* Disable EEE */
+	for (i = 0; i <= 4; i++) {
+		_mt7620_mii_write(gsw, i, 13, 0x7);
+		_mt7620_mii_write(gsw, i, 14, 0x3C);
+		_mt7620_mii_write(gsw, i, 13, 0x4007);
+		_mt7620_mii_write(gsw, i, 14, 0x0);
+	}
+
+	/* Disable EEE 10Base-Te */
+	for (i = 0; i <= 4; i++) {
+		_mt7620_mii_write(gsw, i, 13, 0x1f);
+		_mt7620_mii_write(gsw, i, 14, 0x027b);
+		_mt7620_mii_write(gsw, i, 13, 0x401f);
+		_mt7620_mii_write(gsw, i, 14, 0x1177);
+	}
+
 
 	/* turn on all PHYs */
 	for (i = 0; i <= 4; i++) {

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -562,7 +562,7 @@ static inline u32 fe_empty_txd(struct fe_tx_ring *ring)
 	barrier();
 	return (u32)(ring->tx_ring_size -
 			((ring->tx_next_idx - ring->tx_free_idx) &
-			 (ring->tx_ring_size - 1)));
+			 (ring->tx_ring_size - 1)) - 1);
 }
 
 struct fe_map_state {


### PR DESCRIPTION
try to fix :
Thu Feb 25 10:57:47 2021 kern.info kernel: [71329.735940] mtk_soc_eth 1e100000.ethernet eth0: port 4 link down
Thu Feb 25 10:57:50 2021 kern.info kernel: [71332.757359] mtk_soc_eth 1e100000.ethernet eth0: port 4 link up
