### PR TITLE
package/procd: fix get service running status

### DIFF
--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -407,12 +407,12 @@ _procd_add_instance() {
 
 procd_running() {
 	local service="$1"
-	local instance="${2:-instance1}"
-	local running
+	local instance="${2:-*}"
+	[ "$instance" = "*" ] || instance="'$instance'"
 
 	json_init
 	json_add_string name "$service"
-	running=$(_procd_ubus_call list | jsonfilter -e "@['$service'].instances['$instance'].running")
+	local running=$(_procd_ubus_call list | jsonfilter -l 1 -e "@['$service'].instances[$instance].running")
 
 	[ "$running" = "true" ]
 }


### PR DESCRIPTION
get service running status always return false

procd 脚本 running 命令总是返回1（false），例如 `/etc/init.d/samba4 running` 任何情况下都返回1