### PR TITLE
fix k3screenctrl run faild:SIGSEGV

### DIFF
--- a/target/linux/bcm53xx/patches-5.4/906-BCM5301x-uart1.patch
+++ b/target/linux/bcm53xx/patches-5.4/906-BCM5301x-uart1.patch
@@ -1,0 +1,12 @@
+diff -Nuar a/arch/arm/boot/dts/bcm5301x.dtsi b/arch/arm/boot/dts/bcm5301x.dtsi
+--- a/arch/arm/boot/dts/bcm5301x.dtsi	2021-12-29 16:55:29.441523015 +0800
++++ b/arch/arm/boot/dts/bcm5301x.dtsi	2021-12-29 17:03:44.640694605 +0800
+@@ -38,8 +38,6 @@
+ 			reg = <0x0400 0x100>;
+ 			interrupts = <GIC_SPI 85 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&iprocslow>;
+-			pinctrl-names = "default";
+-			pinctrl-0 = <&pinmux_uart1>;
+ 			status = "disabled";
+ 		};
+ 	};


### PR DESCRIPTION
Phicomm K3's screen wasn't working form kernel 5.4 bump to 5.4.156

Manul run k3screenctrl would out a SIGSEGV error,
It cause by kernel changed some code about serial port's initialization.
This patch to fix this issue.

Patch provided by [ZhangCharlie](https://github.com/ZhangCharlie)