### PR TITLE
Update mt7628an_hiwifi_hc5611.dts

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5611.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5611.dts
@@ -46,7 +46,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};


### PR DESCRIPTION
fix: reset button is not working. The gpio of button is on band1. So the pins should be 32+6.